### PR TITLE
Add support to train NN model on GPU

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,18 @@ Change Log
 ==========
 
 
+v0.3.1 (2021/11/20)
+===================
+
+- add gpu training for NN model; set the ``gpu`` parameter of a calculator (e.g.
+  ``CalculatorTorch(model, gpu=True)``) to use it
+- add pyproject.toml, requirements.txt, dependabot.yml to config repo
+- switch to ``furo`` doc theme
+- changed: compute grad of energy wrt desc in batch mode (NN calculator)
+- fix: set `fingerprints_filename` and load descriptor state dict when reuse fingerprints
+  (NN calculator)
+
+
 v0.3.0 (2021/08/03)
 ===================
 

--- a/examples/example_nn_Si.py
+++ b/examples/example_nn_Si.py
@@ -102,6 +102,8 @@ model.set_save_metadata(prefix="./kliff_saved_model", start=5, frequency=2)
 # :mod:`~kliff.calculators.CalculatorTorch()`, which is targeted for the NN model.
 # Also, its ``create()`` method takes an argument ``reuse`` to inform whether to reuse the
 # fingerprints generated from the descriptor if it is present.
+# To train on gpu, set ``gpu=True`` in ``Calculator``.
+#
 
 # training set
 dataset_path = download_dataset(dataset_name="Si_training_set")
@@ -110,7 +112,7 @@ tset = Dataset(dataset_path)
 configs = tset.get_configs()
 
 # calculator
-calc = CalculatorTorch(model)
+calc = CalculatorTorch(model, gpu=False)
 _ = calc.create(configs, reuse=False)
 
 

--- a/examples/example_nn_SiC.py
+++ b/examples/example_nn_SiC.py
@@ -63,7 +63,7 @@ tset = Dataset(dataset_path)
 configs = tset.get_configs()
 
 # calculator
-calc = CalculatorTorchSeparateSpecies({"Si": model_si, "C": model_c})
+calc = CalculatorTorchSeparateSpecies({"Si": model_si, "C": model_c}, gpu=False)
 _ = calc.create(configs, reuse=False)
 
 # loss

--- a/kliff/calculators/calculator_torch.py
+++ b/kliff/calculators/calculator_torch.py
@@ -27,13 +27,7 @@ class CalculatorTorch:
     implemented_property = ["energy", "forces", "stress"]
 
     def __init__(self, model: ModelTorch, gpu: Union[bool, int] = None):
-
-        device = None
-        if isinstance(gpu, bool):
-            if gpu:
-                device = torch.device(0)
-        elif isinstance(gpu, int):
-            device = torch.dist(gpu)
+        device = _get_device(gpu)
 
         self.model = model.to(device)
         self.dtype = self.model.descriptor.dtype
@@ -245,14 +239,9 @@ class CalculatorTorchSeparateSpecies(CalculatorTorch):
     """
 
     def __init__(self, models: Dict[str, NeuralNetwork], gpu: Union[bool, int] = None):
-        self.models = models
+        device = _get_device(gpu)
 
-        device = None
-        if isinstance(gpu, bool):
-            if gpu:
-                device = torch.device(0)
-        elif isinstance(gpu, int):
-            device = torch.dist(gpu)
+        self.models = models
 
         self.dtype = None
         for s, m in self.models.items():
@@ -412,3 +401,19 @@ class CalculatorTorchError(Exception):
     def __init__(self, msg):
         super(CalculatorTorchError, self).__init__(msg)
         self.msg = msg
+
+
+def _get_device(gpu):
+
+    device = None
+    if isinstance(gpu, bool):
+        if gpu:
+            device = torch.device(0)
+            logger.info(f"Training on gpu")
+    elif isinstance(gpu, int):
+        device = torch.dist(gpu)
+        logger.info(f"Training on gpu: {gpu}")
+    if device is None:
+        logger.info("Training on cpu")
+
+    return device

--- a/kliff/calculators/calculator_torch.py
+++ b/kliff/calculators/calculator_torch.py
@@ -411,7 +411,7 @@ def _get_device(gpu):
             device = torch.device(0)
             logger.info(f"Training on gpu")
     elif isinstance(gpu, int):
-        device = torch.dist(gpu)
+        device = torch.device(gpu)
         logger.info(f"Training on gpu: {gpu}")
     if device is None:
         logger.info("Training on cpu")

--- a/kliff/calculators/calculator_torch.py
+++ b/kliff/calculators/calculator_torch.py
@@ -20,13 +20,22 @@ class CalculatorTorch:
 
     Args:
         model: torch models, e.g. :class:`~kliff.neuralnetwork.NeuralNetwork`.
+        gpu: whether to use gpu for training. If `int` (e.g. 0), will trained on this
+            gpu device. If `True` will always train on gpu `0`.
     """
 
     implemented_property = ["energy", "forces", "stress"]
 
-    def __init__(self, model: ModelTorch):
+    def __init__(self, model: ModelTorch, gpu: Union[bool, int] = None):
 
-        self.model = model
+        device = None
+        if isinstance(gpu, bool):
+            if gpu:
+                device = torch.device(0)
+        elif isinstance(gpu, int):
+            device = torch.dist(gpu)
+
+        self.model = model.to(device)
         self.dtype = self.model.descriptor.dtype
         self.fingerprints_path = None
 
@@ -137,28 +146,29 @@ class CalculatorTorch:
 
     def compute(self, batch):
 
+        #
+        # shape N--number of atoms in a config; D--feature dim
+        # zeta: (N, D)
+        # dzetadr_force: (N, D, 3N)
+        # dzetadr_stress: (N, D, 6)
+        #
+        # batching dzetadr_force seems difficult, because two axes have different size
+        # this seems doable, combine N and 3N as one dim, and use einstein sum
+
+        device = self.model.device
+
         grad = self.use_forces or self.use_stress
 
         # TODO, the batching should be moved to dataloader
         # get information from batch
         zeta_config = [sample["zeta"] for sample in batch]
-        zeta_stacked = torch.cat(zeta_config, dim=0)
+        zeta_stacked = torch.cat(zeta_config, dim=0).to(device)
 
         # evaluate model
         if grad:
             zeta_stacked.requires_grad_(True)
 
         energy_atom = self.model(zeta_stacked)
-        if grad:
-            dedzeta = torch.autograd.grad(
-                energy_atom.sum(), zeta_stacked, create_graph=True
-            )[0]
-            zeta_stacked.requires_grad_(False)  # no need of grad any more
-
-        natoms_config = [len(zeta) for zeta in zeta_config]
-        energy_config = [e.sum() for e in torch.split(energy_atom, natoms_config)]
-        if grad:
-            dedzeta_config = torch.split(dedzeta, natoms_config)
 
         # forces and stress
         if not self.use_forces:
@@ -169,17 +179,28 @@ class CalculatorTorch:
             stress_config = None
         else:
             stress_config = []
+
+        natoms_config = [len(zeta) for zeta in zeta_config]
+        energy_config = [e.sum() for e in torch.split(energy_atom, natoms_config)]
+
         if grad:
+            dedzeta = torch.autograd.grad(
+                energy_atom.sum(), zeta_stacked, create_graph=True
+            )[0]
+            zeta_stacked.requires_grad_(False)  # no need of grad any more
+
+            dedzeta_config = torch.split(dedzeta, natoms_config)
+
             for i, sample in enumerate(batch):
                 dedz = dedzeta_config[i]
 
                 if self.use_forces:
-                    dzetadr_forces = sample["dzetadr_forces"]
+                    dzetadr_forces = sample["dzetadr_forces"].to(device)
                     f = self._compute_forces(dedz, dzetadr_forces)
                     forces_config.append(f)
 
                 if self.use_stress:
-                    dzetadr_stress = sample["dzetadr_stress"]
+                    dzetadr_stress = sample["dzetadr_stress"].to(device)
                     volume = sample["dzetadr_volume"]
                     s = self._compute_stress(dedz, dzetadr_stress, volume)
                     stress_config.append(s)

--- a/kliff/calculators/calculator_torch.py
+++ b/kliff/calculators/calculator_torch.py
@@ -412,7 +412,7 @@ def _get_device(gpu):
             logger.info(f"Training on gpu")
     elif isinstance(gpu, int):
         device = torch.device(gpu)
-        logger.info(f"Training on gpu: {gpu}")
+        logger.info(f"Training on gpu {gpu}")
     if device is None:
         logger.info("Training on cpu")
 

--- a/kliff/loss.py
+++ b/kliff/loss.py
@@ -812,12 +812,14 @@ class LossNeuralNetworkModel(object):
 
     def _get_loss_single_config(self, sample, pred_energy, pred_forces, pred_stress):
 
+        device = self.calculator.model.device
+
         if self.calculator.use_energy:
             pred = pred_energy.reshape(-1)  # reshape scalar as 1D tensor
-            ref = sample["energy"].reshape(-1)
+            ref = sample["energy"].reshape(-1).to(device)
 
         if self.calculator.use_forces:
-            ref_forces = sample["forces"]
+            ref_forces = sample["forces"].to(device)
             if self.calculator.use_energy:
                 pred = torch.cat((pred, pred_forces.reshape(-1)))
                 ref = torch.cat((ref, ref_forces.reshape(-1)))
@@ -826,7 +828,7 @@ class LossNeuralNetworkModel(object):
                 ref = ref_forces.reshape(-1)
 
         if self.calculator.use_stress:
-            ref_stress = sample["stress"]
+            ref_stress = sample["stress"].to(device)
             if self.calculator.use_energy or self.calculator.use_stress:
                 pred = torch.cat((pred, pred_stress.reshape(-1)))
                 ref = torch.cat((ref, ref_stress.reshape(-1)))

--- a/kliff/models/model_torch.py
+++ b/kliff/models/model_torch.py
@@ -121,6 +121,10 @@ class ModelTorch(nn.Module):
     def write_kim_model(self, path: Path = None):
         raise NotImplementedError("`write_kim_model` not implemented.")
 
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
 
 class ModelTorchError(Exception):
     def __init__(self, msg):


### PR DESCRIPTION
To train on GPU, use the `gpu` param, which can be an integer (which gives the index of the gpu) and can be `True` (will use the first gpu). For example, `CalculatorTorch(model, gpu=0)` and `CalculatorTorch(model, gpu=True)`.

Same for multiple species calculator `CalculatorTorchSeparateSpecies`.