### PR TITLE
Fix neighborlist

### DIFF
--- a/docs/source/contributing_guide.rst
+++ b/docs/source/contributing_guide.rst
@@ -4,16 +4,15 @@ Contributing guide
 Code style
 ----------
 
-- KLIFF uses black_ to format the code. It adopts the default style of black_
-  with only one exception: we use line length 90 instead of of the black_default (88).
+- KLIFF uses black_ to format the code. It adopts the default style of black_.
   To format the code, one can use:
 
   .. code-block:: bash
 
-    black --line-length 90 <filename>.py
+    black <filename>.py
 
   Supply ``--skip-string-normalization`` to ``black`` to avoid changing single
-  quote to double quote.
+  quote to double quote (not recommended).
 
 - The docstring of **KLIFF** follows the `numpy` style, which can be found at numpydoc_.
 

--- a/kliff/descriptors/symmetry_function/sym_fn.py
+++ b/kliff/descriptors/symmetry_function/sym_fn.py
@@ -469,9 +469,9 @@ def get_set51():
     for key, values in params.items():
         for val in values:
             if key == "g2":
-                val["eta"] /= bhor2ang ** 2
+                val["eta"] /= bhor2ang**2
             elif key == "g4":
-                val["eta"] /= bhor2ang ** 2
+                val["eta"] /= bhor2ang**2
 
     return params
 
@@ -526,9 +526,9 @@ def get_set30():
     for key, values in params.items():
         for val in values:
             if key == "g2":
-                val["eta"] /= bhor2ang ** 2
+                val["eta"] /= bhor2ang**2
             elif key == "g4":
-                val["eta"] /= bhor2ang ** 2
+                val["eta"] /= bhor2ang**2
 
     return params
 

--- a/kliff/neighbor/helper.hpp
+++ b/kliff/neighbor/helper.hpp
@@ -105,12 +105,15 @@ inline void coords_to_index(double const * x,
 {
   for (int i = 0; i < 3; i++)
   {
-    // set range to std::numeric_limits<double>::epsilon() to handle 1D
-    // and 2D cases where max[i] == min[i]
-    double range = max[i] - min[i] > 0 ? max[i] - min[i]
-                                       : std::numeric_limits<double>::epsilon();
+    //    // set range to std::numeric_limits<double>::epsilon() to handle 1D
+    //    // and 2D cases where max[i] == min[i]
+    //    double range = max[i] - min[i] > 0 ? max[i] - min[i]
+    //                                       :
+    //                                       std::numeric_limits<double>::epsilon();
+    //    index[i] = static_cast<int>((x[i] - min[i]) / range * size[i]);
 
-    index[i] = static_cast<int>((x[i] - min[i]) / range * size[i]);
+    // this assumes max[i] - min[i] is larger than zero
+    index[i] = static_cast<int>((x[i] - min[i]) / (max[i] - min[i]) * size[i]);
 
     // handle edge case when x[i] = max[i]
     index[i] = std::min(index[i], size[i] - 1);

--- a/kliff/neighbor/helper.hpp
+++ b/kliff/neighbor/helper.hpp
@@ -105,10 +105,15 @@ inline void coords_to_index(double const * x,
 {
   for (int i = 0; i < 3; i++)
   {
-    index[i]
-        = static_cast<int>(((x[i] - min[i]) / (max[i] - min[i])) * size[i]);
-    index[i] = std::min(index[i],
-                        size[i] - 1);  // handle edge case when x[i] = max[i]
+    // set range to std::numeric_limits<double>::epsilon() to handle 1D
+    // and 2D cases where max[i] == min[i]
+    double range = max[i] - min[i] > 0 ? max[i] - min[i]
+                                       : std::numeric_limits<double>::epsilon();
+
+    index[i] = static_cast<int>((x[i] - min[i]) / range * size[i]);
+
+    // handle edge case when x[i] = max[i]
+    index[i] = std::min(index[i], size[i] - 1);
   }
 }
 

--- a/kliff/neighbor/neighbor_list.cpp
+++ b/kliff/neighbor/neighbor_list.cpp
@@ -9,7 +9,10 @@
 #include <vector>
 
 #define DIM 3
-#define TOL 1.0e-10
+
+// Should not simply use std::numeric_limits<double>::epsilon(), which is still
+// too small to be distinguishable
+#define TOL 10 * std::numeric_limits<double>::epsilon()
 
 
 void nbl_clean_content(NeighList * const nl)
@@ -88,8 +91,8 @@ int nbl_build(NeighList * const nl,
   for (int k = 0; k < DIM; k++)
   {
     min[k] = coordinates[k];
-    // epsilon to prevent max==min for 1D and 2D case
-    max[k] = coordinates[k] + std::numeric_limits<double>::epsilon();
+    // + TOL to prevent max==min for 1D and 2D case
+    max[k] = coordinates[k] + TOL;
   }
   for (int i = 0; i < numberOfParticles; i++)
   {
@@ -314,8 +317,8 @@ int nbl_create_paddings(int const numberOfParticles,
   // add some extra value to deal with edge case
   for (int i = 0; i < DIM; i++)
   {
-    min[i] -= 1e-10;
-    max[i] += 1e-10;
+    min[i] -= TOL;
+    max[i] += TOL;
   }
 
   // volume of cell


### PR DESCRIPTION
Neighbor list fails for 1D and 2D case where the span of the cell is zero in some directions as reported in #37.  

This is caused by using `std::numeric_limits<double>::epsilon()` when checking the span, which is too small to be distinguishable. Fixed by setting tolerance to `10*epsilon`.