### PR TITLE
Fix to the parameter transformation functionality

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/kliff/models/kim.py
+++ b/kliff/models/kim.py
@@ -626,7 +626,7 @@ class KIMModel(Model):
                     )
 
         # When params_transform is set, a user can do whatever in it
-        # function, e.g. update params is not an optimizing parameter.
+        # function, e.g. update a parameter that is not an optimizing parameter.
         # In general, we do not know how parameters are modified in there,
         # and therefore, we need to update all params in model_params to kim
         # Note, `params_transform.inverse_transform()` is called in

--- a/kliff/models/model.py
+++ b/kliff/models/model.py
@@ -281,7 +281,7 @@ class Model:
     def echo_model_params(
         self,
         filename: Union[Path, TextIO, None] = sys.stdout,
-        parameter_space: str = "original",
+        params_space: str = "original",
     ) -> str:
         """
         Echo the model parameters.
@@ -289,16 +289,16 @@ class Model:
         Args:
             filename: Path to write the model parameter info (e.g. sys.stdout).
                 If `None`, do not write.
-            parameter_space: In which space to show the parameter, options are
-                `original` and `transformed`.
+            params_space: In which space to show the parameters, options are `original`
+                and `transformed`.
 
         Returns:
             model parameter info in a string
         """
 
-        if parameter_space == "original":
+        if params_space == "original":
             params = self.model_params
-        elif parameter_space == "transformed":
+        elif params_space == "transformed":
             if self.params_transform is None:
                 raise RuntimeError(
                     "Cannot obtain parameters in transformed space when "
@@ -309,13 +309,12 @@ class Model:
         else:
             supported = ["original", "transformed"]
             raise ValueError(
-                f"Expect `parameter_space` to be one of {supported}; "
-                "got {parameter_space}"
+                f"Expect `params_space` to be one of {supported}; got {params_space}"
             )
 
         s = "#" + "=" * 80 + "\n"
         s += "# Available parameters to optimize.\n"
-        s += f"# Parameters in `{parameter_space}` space.\n"
+        s += f"# Parameters in `{params_space}` space.\n"
         name = self.__class__.__name__ if self.model_name is None else self.model_name
         s += f"# Model: {name}\n"
 

--- a/kliff/models/parameter.py
+++ b/kliff/models/parameter.py
@@ -391,6 +391,10 @@ class OptimizingParameters(MSONable):
 
         s = "#" + "=" * 80 + "\n"
         s += "# Model parameters that are optimized.\n"
+        s += (
+            "# Note that the parameters are in the transformed space if \n"
+            "# `params_transform` is provided when instantiating the model.\n"
+        )
         s += "#" + "=" * 80 + "\n\n"
 
         for name in self._params:

--- a/kliff/models/parameter.py
+++ b/kliff/models/parameter.py
@@ -391,10 +391,8 @@ class OptimizingParameters(MSONable):
 
         s = "#" + "=" * 80 + "\n"
         s += "# Model parameters that are optimized.\n"
-        s += (
-            "# Note that the parameters are in the transformed space if \n"
-            "# `params_transform` is provided when instantiating the model.\n"
-        )
+        s += "# Note that the parameters are in the transformed space if \n"
+        s += "# `params_transform` is provided when instantiating the model.\n"
         s += "#" + "=" * 80 + "\n\n"
 
         for name in self._params:

--- a/kliff/models/parameter.py
+++ b/kliff/models/parameter.py
@@ -198,13 +198,8 @@ class OptimizingParameters(MSONable):
             of these parameters will be modified to reflect whether it is optimized.
     """
 
-    def __init__(
-        self,
-        model_params: Dict[str, Parameter],
-        params_transform,
-    ):
+    def __init__(self, model_params: Dict[str, Parameter]):
         self.model_params = model_params
-        self.params_transform = params_transform
 
         # list of optimizing param names
         self._params = []
@@ -396,7 +391,6 @@ class OptimizingParameters(MSONable):
 
         s = "#" + "=" * 80 + "\n"
         s += "# Model parameters that are optimized.\n"
-        s += "# The values are presented in the original parameterization.\n"
         s += "#" + "=" * 80 + "\n\n"
 
         for name in self._params:
@@ -462,12 +456,8 @@ class OptimizingParameters(MSONable):
             opt_params: A 1D array of nested optimizing parameter values.
         """
         params = []
-        if self.params_transform is not None:
-            model_params = self.params_transform.transform(self.model_params)
-        else:
-            model_params = self.model_params
         for idx in self._index:
-            params.append(model_params[idx.name][idx.c_idx])
+            params.append(self.model_params[idx.name][idx.c_idx])
         if len(params) == 0:
             raise ParameterError("No parameters specified to optimize.")
 
@@ -486,10 +476,6 @@ class OptimizingParameters(MSONable):
             name = self._index[k].name
             c_idx = self._index[k].c_idx
             self.model_params[name][c_idx] = val
-        if self.params_transform is not None:
-            self.model_params = self.params_transform.inverse_transform(
-                self.model_params
-            )
 
         return self.model_params
 
@@ -503,14 +489,10 @@ class OptimizingParameters(MSONable):
         Args:
             index: slot index of the optimizing parameter
         """
-        if self.params_transform is not None:
-            model_params = self.params_transform(self.model_params)
-        else:
-            model_params = self.model_params
         name = self._index[index].name
         p_idx = self._index[index].p_idx
         c_idx = self._index[index].c_idx
-        value = model_params[name][c_idx]
+        value = self.model_params[name][c_idx]
 
         return name, value, p_idx, c_idx
 

--- a/tests/models/test_kim.py
+++ b/tests/models/test_kim.py
@@ -148,22 +148,26 @@ def test_params_transform():
     A = 15.2848479197914
     B = 0.6022245584
 
-    # Check forward transform.
-    # No log for B since it is not asked to transform
-    assert model.model_params["sigma"][0] == np.log(sigma)
-    assert model.model_params["A"][0] == np.log(A)
+    # Check forward transform (all in original space)
+    assert model.model_params["sigma"][0] == sigma
+    assert model.model_params["A"][0] == A
     assert model.model_params["B"][0] == B
 
-    # optimizing parameters
+    # Transformed params in log space
+    # No log for B since it is not asked to transform
+    assert model.model_params_transformed["sigma"][0] == np.log(sigma)
+    assert model.model_params_transformed["A"][0] == np.log(A)
+    assert model.model_params_transformed["B"][0] == B
+
+    # optimizing parameters, provided in log space
     # B will not be optimized, only providing initial guess
     v1 = 2.0
     v2 = 3.0
     model.set_opt_params(sigma=[[v1]], B=[[B, "fix"]], A=[[v2]])
 
-    # v1 and v2 are supposed to be in log space
-    assert model.model_params["sigma"][0] == v1
-    assert model.model_params["A"][0] == v2
-    assert model.model_params["B"][0] == B
+    assert model.model_params_transformed["sigma"][0] == v1
+    assert model.model_params_transformed["A"][0] == v2
+    assert model.model_params_transformed["B"][0] == B
 
     assert np.allclose(model.get_opt_params(), [v1, v2])
 


### PR DESCRIPTION
List of changes:
* Set `kliff.model.Models().model_params` as an attribute that store
the parameter values in the original parameterization.
* Move the transformation and inverse transform to
`kliff.model.OptimizingParameters()`, e.g., the transform function in `get_opt_params` and
the inverse transform in `update_opt_params` methods. This also requires the parameter
transfomation class to be passed in to `OptimizingParameters`.
* Add a line in the echo methods saying that the printed values are in
the original parameterization.