### PR TITLE
Fix bug if the weight needs configuration's identifier

### DIFF
--- a/docs/source/modules/dataset.rst
+++ b/docs/source/modules/dataset.rst
@@ -309,7 +309,7 @@ weight class that achieve this goal.
             super().__init__(energy_weight=energy_weight, forces_weight=forces_weight)
 
 	def compute_weight(self, config):
-	    identifier = config.identifer
+	    identifier = config.identifier
 	    if 'with_cracks' in identifier:
 		self._config_weight = 10.0
 

--- a/kliff/dataset/dataset.py
+++ b/kliff/dataset/dataset.py
@@ -59,11 +59,11 @@ class Configuration:
         self._forces = forces
         self._stress = stress
 
-        self._weight = Weight() if weight is None else weight
-        self._weight.compute_weight(self)  # Compute the weight
-
         self._identifier = identifier
         self._path = None
+
+        self._weight = Weight() if weight is None else weight
+        self._weight.compute_weight(self)  # Compute the weight
 
     # TODO enable config weight read in from file
     @classmethod


### PR DESCRIPTION
This bug occurs when the weight value depends on the configuration's
identifier. For example, we might want to weigh the configurations
with cracks. The
[documentation](https://kliff.readthedocs.io/en/latest/modules/dataset.html#define-your-weight-class)
shows an example on how this can be done, which uses the identifier to
tell the function whether the configuration has cracks.

Previously, I didn't test this thoroughly and apparently we will get
an error if we apply this example, since the identifier is defined
after `weight.compute_weight()` is called.

I pretty much just swapped the order: now we call
`weight.compute_weight()` after the identifier is defined.