### PR TITLE
Fix bug when we try to set NN parameter with different dtype

### DIFF
--- a/kliff/calculators/calculator_torch.py
+++ b/kliff/calculators/calculator_torch.py
@@ -330,7 +330,8 @@ class CalculatorTorch:
         parameters = self._convert_parameters_from_1d_array(parameters)
         # Update the weights and biases
         for ii, param in enumerate(self.model.parameters()):
-            param.data = parameters[ii]
+            dtype = param.dtype
+            param.data = parameters[ii].type(dtype)
 
     def _convert_parameters_from_1d_array(self, flat_params: np.array) -> List:
         """


### PR DESCRIPTION
torch defaults to use float32. But, maybe we want to update the weights and biases in the NN model using a parameter array written as a numpy array, which defaults to usin float64. This commit fixes this problem and convert the parameter array to use whatever dtype used by the NN model.