### PR TITLE
Order of arguments path and ase_atoms_list was switched in Dataset

### DIFF
--- a/kliff/dataset/dataset.py
+++ b/kliff/dataset/dataset.py
@@ -779,7 +779,7 @@ class Dataset:
         """
         instance = cls()
         instance.add_from_ase(
-            ase_atoms_list, path, weight, energy_key, forces_key, slices, file_format
+            path, ase_atoms_list, weight, energy_key, forces_key, slices, file_format
         )
         return instance
 

--- a/kliff/dataset/dataset.py
+++ b/kliff/dataset/dataset.py
@@ -918,7 +918,7 @@ class Dataset:
         if isinstance(path, str):
             path = Path(path)
         configs = self._read_from_ase(
-            ase_atoms_list, path, weight, energy_key, forces_key, slices
+            path, ase_atoms_list, weight, energy_key, forces_key, slices
         )
         self.configs.extend(configs)
 


### PR DESCRIPTION
## Summary

Two minor changes in dataset.py. Order of arguments given to add_from_ase and _read_from_ase was switched in two cases:

* Dataset.from_ase: instance.add_from_ase(...)
* Dataset.add_from_ase: self._read_from_ase(...)
