### PR TITLE
Kliff master v1

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -60,7 +60,7 @@ jobs:
 
           # install torch dependencies
           # Need to install torch manually as the install group cannot find torch
-          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu 
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
           python -m pip install .[torch]
 
           # TODO, here, we install ptemcee from Yonatan's fork. See setup.py for details.

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,8 @@ jobs:
       matrix:
         #os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+#        python-version: ["3.8", "3.9", "3.10"] # 3.8 does not support typing
+        python-version: ["3.9", "3.10"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         #os: [ubuntu-latest, macos-latest]
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9","3.10","3.11"]
 
     runs-on: ${{ matrix.os }}
 
@@ -45,7 +45,7 @@ jobs:
             python=${{ matrix.python-version }}
             kim-api=2.3.0
             cmake<4.0.0
-            ipcamit::libdescriptor
+            ipcamit::libdescriptor=0.2.5
 
       - name: Install KIM model
         shell: bash -el {0}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pre-commit
+          pip install click>=8.0.0
 
       - name: Lint
         run: pre-commit run --show-diff-on-failure --all-files
@@ -43,6 +44,7 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}
             kim-api=2.3.0
+            cmake<4.0.0
 
       - name: Install KIM model
         shell: bash -el {0}
@@ -56,6 +58,8 @@ jobs:
           python -m pip install .[test]
 
           # install torch dependencies
+          # Need to install torch manually as the install group cannot find torch
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu 
           python -m pip install .[torch]
 
           # TODO, here, we install ptemcee from Yonatan's fork. See setup.py for details.
@@ -65,6 +69,7 @@ jobs:
       - name: Run tests
         shell: bash -el {0}
         run: |
+          export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
           cd tests
           pytest --cov=kliff --cov-report=xml
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,6 +45,7 @@ jobs:
             python=${{ matrix.python-version }}
             kim-api=2.3.0
             cmake<4.0.0
+            ipcamit::libdescriptor
 
       - name: Install KIM model
         shell: bash -el {0}

--- a/docs/source/legacy.rst
+++ b/docs/source/legacy.rst
@@ -44,7 +44,7 @@ Below table illustrates the difference DUNN and TorchML model drivers:
 +----------------+--------------------------------------+------------------------------------------+
 | Performance    | Flexible but slower                  | Faster                                   |
 +----------------+--------------------------------------+------------------------------------------+
-| UQ             | Model dependent                      | Ensemble average                         |
+| UQ             | No UQ support yet                    | Ensemble average                         |
 +----------------+--------------------------------------+------------------------------------------+
 
 So decide as per your requirements which model driver you want to use.

--- a/kliff/models/model_torch.py
+++ b/kliff/models/model_torch.py
@@ -99,7 +99,7 @@ class ModelTorch(nn.Module):
             mode: Purpose of the loaded model. Should be either `train` or `eval`.
         """
         filename = to_path(filename)
-        state_dict = torch.load(str(filename))
+        state_dict = torch.load(str(filename), weights_only=False)
 
         # load model state dict
         self.load_state_dict(state_dict["model_state_dict"])

--- a/kliff/trainer/torch_trainer.py
+++ b/kliff/trainer/torch_trainer.py
@@ -421,8 +421,10 @@ class DNNTrainer(Trainer):
         ):
             self.log_per_atom_outputs(self.current["epoch"], indexes, per_atom_pred)
 
-        if (weights["forces"] is not None and
-                np.array(weights["forces"]).size != forces.shape[0]):
+        if (
+            weights["forces"] is not None
+            and np.array(weights["forces"]).size != forces.shape[0]
+        ):
             weights_forces = np.atleast_2d(weights["forces"])[contribution]
         else:
             weights_forces = weights["forces"]

--- a/kliff/trainer/torch_trainer.py
+++ b/kliff/trainer/torch_trainer.py
@@ -421,6 +421,12 @@ class DNNTrainer(Trainer):
         ):
             self.log_per_atom_outputs(self.current["epoch"], indexes, per_atom_pred)
 
+        if (weights["forces"] is not None and
+                np.array(weights["forces"]).size != forces.shape[0]):
+            weights_forces = np.atleast_2d(weights["forces"])[contribution]
+        else:
+            weights_forces = weights["forces"]
+
         loss_forces = self.loss(
             forces_predicted,
             torch.tensor(
@@ -428,7 +434,7 @@ class DNNTrainer(Trainer):
                 device=self.current["device"],
                 dtype=self.dtype,
             ),
-            weights["forces"],
+            weights_forces,
         )
         # loss = loss + loss_forces * self.loss_manifest["weights"]["forces"]
         # TODO: Discuss and check if this is correct

--- a/tests/trainer/test_descriptor_trainer.py
+++ b/tests/trainer/test_descriptor_trainer.py
@@ -123,12 +123,18 @@ def test_descriptor_trainer():
 
     # check if the kim model is saved, default folder is kim-model
     trainer.save_kim_model()
-    assert os.path.exists("./kim-model/CMakeLists.txt")
+
+    if not trainer.export_manifest["model_name"]:
+        qualified_model_name = f"{trainer.current['run_title']}_MO_000000000000_000"
+    else:
+        qualified_model_name = trainer.export_manifest["model_name"]
+
+    assert os.path.exists(f"./kim-model/{qualified_model_name}/CMakeLists.txt")
 
     # check if checkpoints are properly saved
     ckpt = f'{trainer.current["run_dir"]}/checkpoints/checkpoint_0.pkl'
     assert os.path.exists(ckpt)
-    ckpt_dict = torch.load(ckpt)
+    ckpt_dict = torch.load(ckpt, weights_only=False)
     assert ckpt_dict["model_state_dict"].keys() == model.state_dict().keys()
     assert (
         ckpt_dict["optimizer_state_dict"].keys()

--- a/tests/trainer/test_descriptor_trainer.py
+++ b/tests/trainer/test_descriptor_trainer.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 import yaml
 
-from kliff.trainer import DNNTrainer
+from kliff.trainer.torch_trainer import DNNTrainer
 
 
 def test_descriptor_trainer():
@@ -89,9 +89,8 @@ def test_descriptor_trainer():
 
     expected_loss_manifest = {
         "function": "MSE",
-        "weights": {"config": 1.0, "energy": 1.0, "forces": 1.0, "stress": None},
+        "weights": {"config": 1.0, "energy": 1.0, "forces": 1.0},
         "normalize_per_atom": True,
-        "loss_traj": False,
     }
 
     assert trainer.loss_manifest == expected_loss_manifest
@@ -106,7 +105,7 @@ def test_descriptor_trainer():
     expected_optimizer_manifest = {
         "name": "Adam",
         "learning_rate": 1.0e-3,
-        "kwargs": None,
+        "kwargs": {},
         "epochs": 2,
         "num_workers": None,
         "batch_size": 2,

--- a/tests/trainer/test_kim_trainer.py
+++ b/tests/trainer/test_kim_trainer.py
@@ -8,6 +8,7 @@ import yaml
 from kliff.models import KIMModel
 from kliff.trainer.kim_trainer import KIMTrainer
 
+
 def test_trainer():
     """
     Basic tests for proper initialization of the Trainer module
@@ -98,7 +99,7 @@ def test_trainer():
         "weights": {"config": 1.0, "energy": 1.0, "forces": 1.0},
         "normalize_per_atom": True,
     }
-    print( trainer.loss_manifest, expected_loss_manifest)
+    print(trainer.loss_manifest, expected_loss_manifest)
     assert trainer.loss_manifest == expected_loss_manifest
 
     # dataset samples

--- a/tests/trainer/test_kim_trainer.py
+++ b/tests/trainer/test_kim_trainer.py
@@ -6,8 +6,7 @@ import pytest
 import yaml
 
 from kliff.models import KIMModel
-from kliff.trainer import KIMTrainer
-
+from kliff.trainer.kim_trainer import KIMTrainer
 
 def test_trainer():
     """
@@ -96,10 +95,10 @@ def test_trainer():
 
     expected_loss_manifest = {
         "function": "MSE",
-        "weights": {"config": 1.0, "energy": 1.0, "forces": 1.0, "stress": None},
+        "weights": {"config": 1.0, "energy": 1.0, "forces": 1.0},
         "normalize_per_atom": True,
-        "loss_traj": False,
     }
+    print( trainer.loss_manifest, expected_loss_manifest)
     assert trainer.loss_manifest == expected_loss_manifest
 
     # dataset samples

--- a/tests/trainer/test_lightning_trainer.py
+++ b/tests/trainer/test_lightning_trainer.py
@@ -7,6 +7,7 @@ import yaml
 
 from kliff.trainer.lightning_trainer import GNNLightningTrainer
 
+
 def test_trainer():
     """
     Basic tests for proper initialization of the Trainer module

--- a/tests/trainer/test_lightning_trainer.py
+++ b/tests/trainer/test_lightning_trainer.py
@@ -5,8 +5,7 @@ import pytest
 import torch
 import yaml
 
-from kliff.trainer import GNNLightningTrainer
-
+from kliff.trainer.lightning_trainer import GNNLightningTrainer
 
 def test_trainer():
     """
@@ -57,7 +56,6 @@ def test_trainer():
     assert trainer.current["appending_to_previous_run"] == False
     assert trainer.current["verbose"] == False
     assert trainer.current["ckpt_interval"] == 3
-    assert trainer.current["per_atom_loss"] == {"train": None, "val": None}
 
     # check dataset manifest
     expected_dataset_manifest = {
@@ -76,14 +74,14 @@ def test_trainer():
 
     # check graph settings
     config_transform = {
-        "name": "Graph",
+        "name": "RadialGraph",
         "kwargs": {"cutoff": 3.77, "species": ["Si"], "n_layers": 1},
     }
     assert trainer.transform_manifest["configuration"] == config_transform
 
     expected_loss_manifest = {
         "function": "MSE",
-        "weights": {"config": 1.0, "energy": 1.0, "forces": 10.0, "stress": None},
+        "weights": {"config": 1.0, "energy": 1.0, "forces": 10.0},
         "normalize_per_atom": False,
         "loss_traj": False,
     }
@@ -99,11 +97,12 @@ def test_trainer():
     expected_optimizer_manifest = {
         "name": "Adam",
         "learning_rate": 0.001,
-        "kwargs": None,
+        "kwargs": {},
         "epochs": 2,
         "num_workers": None,
         "batch_size": 1,
     }
+    print(trainer.optimizer_manifest, expected_optimizer_manifest)
     assert trainer.optimizer_manifest == expected_optimizer_manifest
 
     # dummy training

--- a/tests/trainer/test_lightning_trainer.py
+++ b/tests/trainer/test_lightning_trainer.py
@@ -117,9 +117,15 @@ def test_trainer():
 
     # check if the kim model is saved, default folder is kim-model
     trainer.save_kim_model()
-    assert Path(f"kim-model/model.pt").exists()
-    assert Path(f"kim-model/kliff_graph.param").exists()
-    assert Path(f"kim-model/CMakeLists.txt").exists()
+
+    if not trainer.export_manifest["model_name"]:
+        qualified_model_name = f"{trainer.current['run_title']}_MO_000000000000_000"
+    else:
+        qualified_model_name = trainer.export_manifest["model_name"]
+
+    assert Path(f"kim-model/{qualified_model_name}/model.pt").exists()
+    assert Path(f"kim-model/{qualified_model_name}/kliff_graph.param").exists()
+    assert Path(f"kim-model/{qualified_model_name}/CMakeLists.txt").exists()
 
     # check restart
     # TODO: implement restart test


### PR DESCRIPTION
- Removed 3.8 support. python 3.8 does not support all the typing hints.
- converted all `torch.load` commands to `torch.load(, weights_only=False)`. Newer pytorch versions give error.
- Corrections to tests
- Corrected weights broadcasting in the DNNTrainer (batching now also works with scalar weights)

